### PR TITLE
feat: Customizing max size of returned base64 image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,17 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 - Remove additional fallback when getting the `year` metadata field for `MetadataRetriever` method.
   - No longer fallbacks to using `MediaMetadataRetriever` if everything else fails.
 
+### 🎉 Added
+
+- New `updateConfigs` function.
+  - Change the max base64 image size that can be returned with `maxImageSizeMB` option.
+
 ### ⚙️ Internal Changes
 
 - Reorganization of code.
   - Now "normalize" and put all the field-value pairs inside a map, which we then send the ones we want to return.
 - Ensure we release `MetadataRetriever` & `MediaMetadataRetriever` when we're done using them.
+- Update example app.
 
 ## [1.1.0] - 2025-08-21
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,29 @@ Returns the specified metadata of the provided uri based on the `options` argume
 
 > **Note:** The "complicated" typing is to make the resulting promise type-safe and be based off the provided `options`.
 
+### updateConfigs
+
+```ts
+function updateConfigs(options: ConfigOptions): void;
+```
+
+Update internal configuration options such as the max base64 image size returned.
+
 ## Types
+
+### ConfigOptions
+
+```ts
+type ConfigOptions = {
+  /**
+   * Size of the returned base64 image in MB.
+   * - Defaults to `5`.
+   */
+  maxImageSizeMB?: number | null;
+};
+```
+
+Configuration options we can set to modify the behavior of the package.
 
 ### MediaMetadata
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Returns the specified metadata of the provided uri based on the `options` argume
 ### updateConfigs
 
 ```ts
-function updateConfigs(options: ConfigOptions): void;
+function updateConfigs(options: ConfigOptions): Promise<void>;
 ```
 
 Update internal configuration options such as the max base64 image size returned.

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/MetadataRetrieverModule.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/MetadataRetrieverModule.kt
@@ -19,7 +19,7 @@ import androidx.media3.exoplayer.MetadataRetriever
 import java.util.concurrent.ExecutionException
 
 import com.cyanchill.missingcore.metadataretriever.models.MetadataReader
-import com.cyanchill.missingcore.metadataretriever.utils.BundleUtils
+import com.cyanchill.missingcore.metadataretriever.modules.APIConfigs
 import com.cyanchill.missingcore.metadataretriever.utils.MapUtils
 import com.cyanchill.missingcore.metadataretriever.utils.Normalization
 
@@ -29,11 +29,7 @@ class MetadataRetrieverModule internal constructor(reactContext: ReactApplicatio
   MetadataRetrieverSpec(reactContext) {
   private val context = reactContext
 
-  /**
-   * Supported values:
-   *  - MAX_IMAGE_SIZE_MB: Double?
-   */
-  private var apiConfigs = Bundle()
+  private var apiConfigs = APIConfigs()
 
   @ReactMethod
   override fun getMetadata(uri: String, options: ReadableArray, promise: Promise) {
@@ -224,7 +220,7 @@ class MetadataRetrieverModule internal constructor(reactContext: ReactApplicatio
   /** Expose to the user the ability to update internal configuration options. */
   @ReactMethod
   override fun updateConfigs(options: Bundle) {
-    BundleUtils.putDoubleIfExists(MAX_IMAGE_SIZE_MB, options, apiConfigs)
+    apiConfigs.updateConfigs(options)
   }
 
   //#region [Internal Helpers]
@@ -266,10 +262,6 @@ class MetadataRetrieverModule internal constructor(reactContext: ReactApplicatio
 
   companion object {
     const val NAME = "MetadataRetriever"
-
-    //#region [Config Option Keys]
-    const val MAX_IMAGE_SIZE_MB = "maxImageSizeMB"
-    //#endregion
   }
 
   override fun getName(): String = NAME

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/MetadataRetrieverModule.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/MetadataRetrieverModule.kt
@@ -3,11 +3,11 @@ package com.cyanchill.missingcore.metadataretriever
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 
 import android.media.MediaMetadataRetriever
-import android.os.Bundle
 import androidx.annotation.OptIn
 import androidx.media3.common.C
 import androidx.media3.common.Format
@@ -219,8 +219,11 @@ class MetadataRetrieverModule internal constructor(reactContext: ReactApplicatio
 
   /** Expose to the user the ability to update internal configuration options. */
   @ReactMethod
-  override fun updateConfigs(options: Bundle) {
-    apiConfigs.updateConfigs(options)
+  override fun updateConfigs(options: ReadableMap, promise: Promise) {
+    Arguments.toBundle(options)?.let {
+      apiConfigs.updateConfigs(it)
+    }
+    promise.resolve(null)
   }
 
   //#region [Internal Helpers]

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/MetadataRetrieverModule.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/MetadataRetrieverModule.kt
@@ -7,6 +7,7 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 
 import android.media.MediaMetadataRetriever
+import android.os.Bundle
 import androidx.annotation.OptIn
 import androidx.media3.common.C
 import androidx.media3.common.Format
@@ -18,6 +19,7 @@ import androidx.media3.exoplayer.MetadataRetriever
 import java.util.concurrent.ExecutionException
 
 import com.cyanchill.missingcore.metadataretriever.models.MetadataReader
+import com.cyanchill.missingcore.metadataretriever.utils.BundleUtils
 import com.cyanchill.missingcore.metadataretriever.utils.MapUtils
 import com.cyanchill.missingcore.metadataretriever.utils.Normalization
 
@@ -26,6 +28,12 @@ import com.cyanchill.missingcore.metadataretriever.utils.Normalization
 class MetadataRetrieverModule internal constructor(reactContext: ReactApplicationContext) :
   MetadataRetrieverSpec(reactContext) {
   private val context = reactContext
+
+  /**
+   * Supported values:
+   *  - MAX_IMAGE_SIZE_MB: Double?
+   */
+  private var apiConfigs = Bundle()
 
   @ReactMethod
   override fun getMetadata(uri: String, options: ReadableArray, promise: Promise) {
@@ -213,6 +221,12 @@ class MetadataRetrieverModule internal constructor(reactContext: ReactApplicatio
     }
   }
 
+  /** Expose to the user the ability to update internal configuration options. */
+  @ReactMethod
+  override fun updateConfigs(options: Bundle) {
+    BundleUtils.putDoubleIfExists(MAX_IMAGE_SIZE_MB, options, apiConfigs)
+  }
+
   //#region [Internal Helpers]
   /**
    * Returns a list of `Format` from an uri.
@@ -252,6 +266,10 @@ class MetadataRetrieverModule internal constructor(reactContext: ReactApplicatio
 
   companion object {
     const val NAME = "MetadataRetriever"
+
+    //#region [Config Option Keys]
+    const val MAX_IMAGE_SIZE_MB = "maxImageSizeMB"
+    //#endregion
   }
 
   override fun getName(): String = NAME

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/MetadataRetrieverModule.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/MetadataRetrieverModule.kt
@@ -18,8 +18,7 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.MetadataRetriever
 import java.util.concurrent.ExecutionException
 
-import com.cyanchill.missingcore.metadataretriever.models.MetadataReader
-import com.cyanchill.missingcore.metadataretriever.modules.APIConfigs
+import com.cyanchill.missingcore.metadataretriever.modules.MetadataReader
 import com.cyanchill.missingcore.metadataretriever.utils.MapUtils
 import com.cyanchill.missingcore.metadataretriever.utils.Normalization
 
@@ -29,7 +28,7 @@ class MetadataRetrieverModule internal constructor(reactContext: ReactApplicatio
   MetadataRetrieverSpec(reactContext) {
   private val context = reactContext
 
-  private var apiConfigs = APIConfigs()
+  private var reader = MetadataReader()
 
   @ReactMethod
   override fun getMetadata(uri: String, options: ReadableArray, promise: Promise) {
@@ -59,10 +58,10 @@ class MetadataRetrieverModule internal constructor(reactContext: ReactApplicatio
         mmrMetadata.setDataSource(Normalization.getSafeUri(uri))
       }
 
-      val formatMetadataDataMap = MetadataReader.fromFormat(formatList[0])
+      val formatMetadataDataMap = reader.fromFormat(formatList[0])
       val metadataDataMap = when (mmrMetadata) {
-        null -> MetadataReader.fromMediaMetadata(mediaMetadata, wantArtwork)
-        else -> MetadataReader.fromMediaMetadataRetriever(mmrMetadata, wantArtwork)
+        null -> reader.fromMediaMetadata(mediaMetadata, wantArtwork)
+        else -> reader.fromMediaMetadataRetriever(mmrMetadata, wantArtwork)
       }
 
       var recheckBitRate = false
@@ -160,7 +159,7 @@ class MetadataRetrieverModule internal constructor(reactContext: ReactApplicatio
       if (metadataList.isEmpty()) {
         val mmrMetadata = MediaMetadataRetriever()
         mmrMetadata.setDataSource(Normalization.getSafeUri(uri))
-        promise.resolve(MetadataReader.getBase64Image(mmrMetadata.getEmbeddedPicture()))
+        promise.resolve(reader.getBase64Image(mmrMetadata.getEmbeddedPicture()))
         mmrMetadata.release()
         return
       }
@@ -180,7 +179,7 @@ class MetadataRetrieverModule internal constructor(reactContext: ReactApplicatio
           // "Other" Picture Type
           MediaMetadata.PICTURE_TYPE_OTHER -> {
             if (backupImage == null || backupImageCode == 1) {
-              val newImg = MetadataReader.getBase64Image(mediaMetadata.artworkData)
+              val newImg = reader.getBase64Image(mediaMetadata.artworkData)
               if (newImg !== null) {
                 backupImage = newImg
                 backupImageCode = 3
@@ -190,13 +189,13 @@ class MetadataRetrieverModule internal constructor(reactContext: ReactApplicatio
           // "32x32 pixels 'file icon' (PNG only)" Picture Type
           MediaMetadata.PICTURE_TYPE_FILE_ICON -> {
             if (backupImage == null) {
-              backupImage = MetadataReader.getBase64Image(mediaMetadata.artworkData)
+              backupImage = reader.getBase64Image(mediaMetadata.artworkData)
               backupImageCode = 1
             }
           }
           // "Cover (front)" Picture Type
           MediaMetadata.PICTURE_TYPE_FRONT_COVER -> {
-            coverImage = MetadataReader.getBase64Image(mediaMetadata.artworkData)
+            coverImage = reader.getBase64Image(mediaMetadata.artworkData)
           }
         }
 
@@ -221,7 +220,7 @@ class MetadataRetrieverModule internal constructor(reactContext: ReactApplicatio
   @ReactMethod
   override fun updateConfigs(options: ReadableMap, promise: Promise) {
     Arguments.toBundle(options)?.let {
-      apiConfigs.updateConfigs(it)
+      reader.updateConfigs(it)
     }
     promise.resolve(null)
   }

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/APIConfigs.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/APIConfigs.kt
@@ -1,0 +1,22 @@
+package com.cyanchill.missingcore.metadataretriever.modules
+
+import android.os.Bundle
+
+import com.cyanchill.missingcore.metadataretriever.utils.BundleUtils
+
+class APIConfigs {
+  /**
+   * Supported values:
+   *  - MAX_IMAGE_SIZE_MB: Double?
+   */
+  var apiConfigs = Bundle()
+
+  /** Partially update `apiConfigs` based on set values. */
+  fun updateConfigs(options: Bundle) {
+    BundleUtils.putDoubleIfExists(MAX_IMAGE_SIZE_MB, options, apiConfigs)
+  }
+
+  companion object {
+    const val MAX_IMAGE_SIZE_MB = "maxImageSizeMB"
+  }
+}

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/APIConfigs.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/APIConfigs.kt
@@ -9,7 +9,7 @@ open class APIConfigs {
    * Supported values:
    *  - MAX_IMAGE_SIZE_MB: Double?
    */
-  var apiConfigs = Bundle()
+  protected var apiConfigs = Bundle()
 
   /** Partially update `apiConfigs` based on set values. */
   fun updateConfigs(options: Bundle) {

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/APIConfigs.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/APIConfigs.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 
 import com.cyanchill.missingcore.metadataretriever.utils.BundleUtils
 
-class APIConfigs {
+open class APIConfigs {
   /**
    * Supported values:
    *  - MAX_IMAGE_SIZE_MB: Double?

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataReader.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataReader.kt
@@ -141,7 +141,7 @@ class MetadataReader: APIConfigs {
 
   //#region [Exposed Helpers To Parse Metadata Values]
   /** Returns a base64 image string from a `ByteArray`. */
-  fun getBase64Image(bytes: ByteArray? = null, maxSizeMB: Double = 5.0): String? {
+  fun getBase64Image(bytes: ByteArray? = null): String? {
     if (bytes == null) return null
     // Determine the mimetype from bytes.
     val mimeType = URLConnection.guessContentTypeFromStream(bytes.inputStream())?.let {
@@ -151,6 +151,7 @@ class MetadataReader: APIConfigs {
     if (!MimeTypes.isImage(mimeType)) return null
     // Convert max MB to bytes. We take 3/4 of the max MB as converting a byte array to a base64
     // string causes a 33% increase in size.
+    val maxSizeMB = apiConfigs.getDouble(MAX_IMAGE_SIZE_MB, 5.0)
     val maxSizeBytes = maxSizeMB * 0.75 * 1024 * 1024
     if (bytes.size > maxSizeBytes) return null
     return "data:$mimeType;base64,${Base64.encodeToString(bytes, Base64.DEFAULT)}"

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataReader.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataReader.kt
@@ -15,9 +15,7 @@ import java.net.URLConnection
  * Utilities to format & normalize sources of metadata as a map.
  */
 @OptIn(UnstableApi::class)
-class MetadataReader: APIConfigs {
-  constructor(): super()
-
+class MetadataReader: APIConfigs() {
   /**
    * Relevant metadata fields found on `Format`.
    *

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataReader.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataReader.kt
@@ -1,4 +1,4 @@
-package com.cyanchill.missingcore.metadataretriever.models
+package com.cyanchill.missingcore.metadataretriever.modules
 
 import android.media.MediaMetadataRetriever
 import android.util.Base64
@@ -15,7 +15,9 @@ import java.net.URLConnection
  * Utilities to format & normalize sources of metadata as a map.
  */
 @OptIn(UnstableApi::class)
-object MetadataReader {
+class MetadataReader: APIConfigs {
+  constructor(): super()
+
   /**
    * Relevant metadata fields found on `Format`.
    *

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/utils/BundleUtils.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/utils/BundleUtils.kt
@@ -1,0 +1,9 @@
+package com.cyanchill.missingcore.metadataretriever.utils
+
+import android.os.Bundle
+
+object BundleUtils {
+  fun putDoubleIfExists(key: String, data: Bundle, store: Bundle) {
+    if (data.containsKey(key)) store.putDouble(key, data.getDouble(key))
+  }
+}

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/utils/BundleUtils.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/utils/BundleUtils.kt
@@ -3,7 +3,15 @@ package com.cyanchill.missingcore.metadataretriever.utils
 import android.os.Bundle
 
 object BundleUtils {
+  fun getDoubleOrNull(key: String, data: Bundle): Double? {
+    return data[key] as? Double
+  }
+
   fun putDoubleIfExists(key: String, data: Bundle, store: Bundle) {
-    if (data.containsKey(key)) store.putDouble(key, data.getDouble(key))
+    if (data.containsKey(key)) {
+      val value = getDoubleOrNull(key, data)
+      if (value != null) store.putDouble(key, value)
+      else store.remove(key)
+    }
   }
 }

--- a/android/src/oldarch/MetadataRetrieverSpec.kt
+++ b/android/src/oldarch/MetadataRetrieverSpec.kt
@@ -3,9 +3,8 @@ package com.cyanchill.missingcore.metadataretriever
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.Promise
-
-import android.os.Bundle
 
 abstract class MetadataRetrieverSpec internal constructor(context: ReactApplicationContext) :
   ReactContextBaseJavaModule(context) {
@@ -13,5 +12,5 @@ abstract class MetadataRetrieverSpec internal constructor(context: ReactApplicat
 
   abstract fun getArtwork(uri: String, promise: Promise)
 
-  abstract fun updateConfigs(options: Bundle)
+  abstract fun updateConfigs(options: ReadableMap, promise: Promise)
 }

--- a/android/src/oldarch/MetadataRetrieverSpec.kt
+++ b/android/src/oldarch/MetadataRetrieverSpec.kt
@@ -5,9 +5,13 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.Promise
 
+import android.os.Bundle
+
 abstract class MetadataRetrieverSpec internal constructor(context: ReactApplicationContext) :
   ReactContextBaseJavaModule(context) {
   abstract fun getMetadata(uri: String, options: ReadableArray, promise: Promise)
 
   abstract fun getArtwork(uri: String, promise: Promise)
+
+  abstract fun updateConfigs(options: Bundle)
 }

--- a/examples/benchmarking-demo/App.tsx
+++ b/examples/benchmarking-demo/App.tsx
@@ -18,6 +18,7 @@ import {
 import {
   MetadataPresets,
   getMetadata,
+  updateConfigs,
 } from '@missingcore/react-native-metadata-retriever';
 
 import { isFulfilled, isRejected } from './utils/promise';
@@ -25,6 +26,8 @@ import { isFulfilled, isRejected } from './utils/promise';
 const queryClient = new QueryClient();
 
 async function getTracks() {
+  await updateConfigs({ maxImageSizeMB: 0.5 });
+
   const start = performance.now();
 
   const { totalCount } = await MediaLibrary.getAssetsAsync({

--- a/src/NativeMetadataRetriever.ts
+++ b/src/NativeMetadataRetriever.ts
@@ -8,6 +8,8 @@ export interface Spec extends TurboModule {
   ): Promise<Record<string, unknown>>;
 
   getArtwork(uri: string): Promise<string | null>;
+
+  updateConfigs(options: Record<string, any>): void;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('MetadataRetriever');

--- a/src/NativeMetadataRetriever.ts
+++ b/src/NativeMetadataRetriever.ts
@@ -9,7 +9,7 @@ export interface Spec extends TurboModule {
 
   getArtwork(uri: string): Promise<string | null>;
 
-  updateConfigs(options: Record<string, any>): void;
+  updateConfigs(options: Record<string, any>): Promise<void>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('MetadataRetriever');

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -122,5 +122,9 @@ export type MediaMetadataExcerpt<TKeys extends MediaMetadataPublicFields> =
   Prettify<Pick<MediaMetadata, TKeys[number]>>;
 
 export type ConfigOptions = {
+  /**
+   * Size of the returned base64 image in MB.
+   * - Defaults to `5`.
+   */
   maxImageSizeMB?: number | null;
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -120,3 +120,7 @@ export type MediaMetadata = {
 /** Returns a type-safe excerpt of `MediaMetadata`. */
 export type MediaMetadataExcerpt<TKeys extends MediaMetadataPublicFields> =
   Prettify<Pick<MediaMetadata, TKeys[number]>>;
+
+export type ConfigOptions = {
+  maxImageSizeMB?: number | null;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export function getArtwork(uri: string): Promise<string | null> {
 }
 
 /** Expose to the user the ability to update internal configuration options. */
-export function updateConfigs(options: ConfigOptions): void {
+export function updateConfigs(options: ConfigOptions): Promise<void> {
   return MetadataRetriever.updateConfigs(options);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ export function updateConfigs(options: ConfigOptions): void {
 }
 
 export {
+  type ConfigOptions,
   type MediaMetadata,
   type MediaMetadataExcerpt,
   type MediaMetadataPublicField,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import MetadataRetriever from './MetadataRetriever';
 
 import type {
+  ConfigOptions,
   MediaMetadata,
   MediaMetadataExcerpt,
   MediaMetadataPublicField,
@@ -24,6 +25,11 @@ export function getMetadata<TOptions extends MediaMetadataPublicFields>(
  */
 export function getArtwork(uri: string): Promise<string | null> {
   return MetadataRetriever.getArtwork(uri);
+}
+
+/** Expose to the user the ability to update internal configuration options. */
+export function updateConfigs(options: ConfigOptions): void {
+  return MetadataRetriever.updateConfigs(options);
 }
 
 export {


### PR DESCRIPTION
This PR adds the ability to change the max size of the returned base64 image via a new `updateConfigs` function, which previously was fixed to `5 MB`.

### Changes
- New `APIConfig` class to store the global API configs that we can change (currently only supports `maxImageSizeMB`).
- Moved `MetadataReader` to `modules` folder.
- Revised `MetadataReader.getBase64Image` to calculate `maxSizeMB` from `maxImageSizeMB` from `APIConfig`.
- New "Bundle Utils" to deal with accessing values in bundles.
  - `Bundle.getDouble()` will return `0.0` if the value at a key is set to `null`, which we don't want as we do want to read `null` if possible.
