### PR TITLE
feat: Support for getting the metadata of multiple URIs at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,15 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - New `updateConfigs` function.
   - Customize the max size of the returned base64 image with the `maxImageSizeMB` option.
+- New `getBulkMetadata` function.
+  - Slightly different than `getMetadata` as this function won't throw an error. It'll return an object with 2 fields, `results` & `errors` which contain an array of objects containing the URI & data/error associated with it.
 
 ### ⚙️ Internal Changes
 
 - Reorganization of code.
   - Now "normalize" and put all the field-value pairs inside a map, which we then send the ones we want to return.
 - Ensure we release `MetadataRetriever` & `MediaMetadataRetriever` when we're done using them.
-- Update example app.
+- Updated example app to use `getBulkMetadata` instead of `getMetadata`.
 
 ## [1.1.0] - 2025-08-21
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ Returns the base64 image string for the media file of the provided uri.
 
 > **Note:** Defaults to returning up to `5 MB` of data. Can be configured with [`updateConfigs`](#updateConfigs).
 
+### getBulkMetadata
+
+```ts
+function getBulkMetadata<TOptions extends MediaMetadataPublicFields>(
+  uris: string[],
+  options: TOptions
+): Promise<BulkMetadata<TOptions>>;
+```
+
+Get the metadata of multiple URIs.
+
 ### getMetadata
 
 ```ts
@@ -74,7 +85,7 @@ function getMetadata<TOptions extends MediaMetadataPublicFields>(
 ): Promise<MediaMetadataExcerpt<TOptions>>;
 ```
 
-Returns the specified metadata of the provided uri based on the `options` argument.
+Returns the specified metadata of the provided uri based on the `options` argument. Throws error if something went wrong.
 
 > **Note:** The "complicated" typing is to make the resulting promise type-safe and be based off the provided `options`.
 
@@ -87,6 +98,23 @@ function updateConfigs(options: ConfigOptions): Promise<void>;
 Update internal configuration options such as the max size of the returned base64 image.
 
 ## Types
+
+### BulkMetadata
+
+```ts
+type BulkMetadata<TKeys extends MediaMetadataPublicFields> = {
+  results: Array<{
+    uri: string;
+    data: MediaMetadataExcerpt<TKeys>;
+  }>;
+  errors: Array<{
+    uri: string;
+    data: { name: string; message: string };
+  }>;
+};
+```
+
+Structure returned when using `getBulkMetadata`.
 
 ### ConfigOptions
 

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/MetadataRetrieverModule.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/MetadataRetrieverModule.kt
@@ -152,8 +152,8 @@ class MetadataRetrieverModule internal constructor(reactContext: ReactApplicatio
     // Release `MediaMetadataRetriever` resources.
     mmrMetadata.release()
 
-    returnObj.putArray("success", successArr)
-    returnObj.putArray("error", errorArr)
+    returnObj.putArray("results", successArr)
+    returnObj.putArray("errors", errorArr)
 
     promise.resolve(returnObj)
   }

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/MetadataRetrieverModule.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/MetadataRetrieverModule.kt
@@ -1,11 +1,11 @@
 package com.cyanchill.missingcore.metadataretriever
 
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.bridge.Arguments
-import com.facebook.react.bridge.Promise
 
 import android.media.MediaMetadataRetriever
 import android.os.Bundle
@@ -19,6 +19,7 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.MetadataRetriever
 import java.util.concurrent.ExecutionException
 
+import com.cyanchill.missingcore.metadataretriever.models.BridgeReturnables.*
 import com.cyanchill.missingcore.metadataretriever.modules.MetadataReader
 import com.cyanchill.missingcore.metadataretriever.utils.MapUtils
 import com.cyanchill.missingcore.metadataretriever.utils.Normalization
@@ -32,115 +33,129 @@ class MetadataRetrieverModule internal constructor(reactContext: ReactApplicatio
   private var reader = MetadataReader()
 
   @ReactMethod
-  override fun getMetadata(uri: String, options: ReadableArray, promise: Promise) {
+  override fun getBulkMetadata(uris: ReadableArray, options: ReadableArray, promise: Promise) {
+    val uriList = Arguments.toList(uris) as List<String>
     val optionsList = Arguments.toList(options) as List<String>
 
-    // Populate return object with default values based on input.
-    val metadataMap = Arguments.createMap()
-    optionsList.forEach { fieldName -> metadataMap.putNull(fieldName) }
+    val returnObj = Arguments.createMap()
+    val successArr = Arguments.createArray()
+    val errorArr = Arguments.createArray()
+
+    // Generate the structure of the object we want to return.
+    val returnMetadataStructure = Arguments.createMap()
+    optionsList.forEach { fieldName -> returnMetadataStructure.putNull(fieldName) }
+
     val wantArtwork = optionsList.any { fieldName -> fieldName == "artworkData" }
 
     // Move outside of try-catch block so we can release it in finally.
-    var mmrMetadata: MediaMetadataRetriever? = null
+    var mmrMetadata = MediaMetadataRetriever()
+    var mmrSource: String? = null
 
-    try {
-      val formatList = getFormatList(uri)
-      val mediaMetadata = MediaMetadata.Builder()
-        .populateFromMetadata(getMetadataList(formatList))
-        .build()
+    for (uri in uriList) {
+      try {
+        val metadataMap = returnMetadataStructure.copy()
 
-      // Fallback to `MediaMetadataRetriever` if we find nothing with `MetadataRetriever` (in the case
-      // with `ID3v1` tags).
-      if (mediaMetadata == MediaMetadata.EMPTY) {
-        mmrMetadata = MediaMetadataRetriever()
-        mmrMetadata.setDataSource(Normalization.getSafeUri(uri))
-      }
+        val formatList = getFormatList(uri)
+        val mediaMetadata = MediaMetadata.Builder()
+          .populateFromMetadata(getMetadataList(formatList))
+          .build()
 
-      val formatMetadataDataMap = reader.fromFormat(formatList[0])
-      val metadataDataMap = when (mmrMetadata) {
-        null -> reader.fromMediaMetadata(mediaMetadata, wantArtwork)
-        else -> reader.fromMediaMetadataRetriever(mmrMetadata, wantArtwork)
-      }
-
-      var recheckBitRate = false
-      // Populate return object with the metadata we found.
-      for (field in optionsList) {
-        // Use scope functions to help determine output.
-        // SEE https://kotlinlang.org/docs/scope-functions.html
-        when (field) {
-          /** List of fields available on `Format`. */
-          "bitrate" -> {
-            val foundBitRate = MapUtils.getInt(formatMetadataDataMap, "bitrate")
-            if (foundBitRate != null) {
-              metadataMap.putInt(field, foundBitRate)
-              // Recheck bitrate if less than 96kbps as the value should typically be greater than this.
-              // This also handles the case where variable bitrate isn't probably returned as I've seen
-              // it be set to `64000`.
-              if (foundBitRate < 96000) recheckBitRate = true
-            } else recheckBitRate = true
-          }
-
-          "channelCount", "sampleRate" ->
-            MapUtils.getInt(formatMetadataDataMap, field)?.let { metadataMap.putInt(field, it) }
-
-          "codecs", "sampleMimeType" ->
-            MapUtils.getString(formatMetadataDataMap, field)?.let { metadataMap.putString(field, it) }
-
-          /** List of fields available on `MediaMetadata`. */
-          "albumArtist", "albumTitle", "artist", "artworkData", "artworkDataType", "artworkUri",
-          "compilation", "composer", "conductor", "description", "displayTitle", "genre", "mediaType",
-          "station", "subtitle", "title", "writer" ->
-            MapUtils.getString(metadataDataMap, field)?.let { metadataMap.putString(field, it) }
-
-          "discNumber", "recordingDay", "recordingMonth", "recordingYear", "releaseDay", "releaseMonth",
-          "releaseYear", "totalDiscCount", "totalTrackCount", "trackNumber", "year" ->
-            MapUtils.getInt(metadataDataMap, field)?.let { metadataMap.putInt(field, it) }
-
-          "isBrowsable", "isPlayable" ->
-            MapUtils.getBoolean(metadataDataMap, field)?.let { metadataMap.putBoolean(field, it) }
-
-          "overallRating", "userRating" ->
-            MapUtils.getDouble(metadataDataMap, field)?.let { metadataMap.putDouble(field, it) }
-        }
-      }
-
-      // Compute bitrate using `MediaMetadataRetriever` if wanted and not found. Necessary for FLAC
-      // files as `Format` doesn't populate that field for whatever reason.
-      if (recheckBitRate) {
-        // Ensure the `MediaMetadataRetriever` object exists.
-        if (mmrMetadata == null) {
-          mmrMetadata = MediaMetadataRetriever()
+        // Fallback to `MediaMetadataRetriever` if we find nothing with `MetadataRetriever` (in the case
+        // with `ID3v1` tags).
+        if (mediaMetadata == MediaMetadata.EMPTY) {
           mmrMetadata.setDataSource(Normalization.getSafeUri(uri))
+          mmrSource = uri
         }
-        mmrMetadata.extractMetadata(MediaMetadataRetriever.METADATA_KEY_BITRATE)?.toIntOrNull()?.let { metadataMap.putInt("bitrate", it) }
-      }
 
-      // Have `albumArtist` fallback to `artist` value if it's not defined, but only when certain
-      // conditions are met (`artist` & `albumTitle` fields are defined).
-      if (metadataMap.hasKey("albumArtist") && metadataMap.isNull("albumArtist")) {
-        if (
-          metadataMap.hasKey("artist") && !metadataMap.isNull("artist") &&
-          metadataMap.hasKey("albumTitle") && !metadataMap.isNull("albumTitle")
+        val formatMetadataDataMap = reader.fromFormat(formatList[0])
+        val metadataDataMap = when (mmrSource == uri) {
+          true -> reader.fromMediaMetadataRetriever(mmrMetadata, wantArtwork)
+          false -> reader.fromMediaMetadata(mediaMetadata, wantArtwork)
+        }
+
+        var recheckBitRate = false
+        // Populate return object with the metadata we found.
+        for (field in optionsList) {
+          // Use scope functions to help determine output.
+          // SEE https://kotlinlang.org/docs/scope-functions.html
+          when (field) {
+            /** List of fields available on `Format`. */
+            "bitrate" -> {
+              val foundBitRate = MapUtils.getInt(formatMetadataDataMap, "bitrate")
+              if (foundBitRate != null) {
+                metadataMap.putInt(field, foundBitRate)
+                // Recheck bitrate if less than 96kbps as the value should typically be greater than this.
+                // This also handles the case where variable bitrate isn't probably returned as I've seen
+                // it be set to `64000`.
+                if (foundBitRate < 96000) recheckBitRate = true
+              } else recheckBitRate = true
+            }
+
+            "channelCount", "sampleRate" ->
+              MapUtils.getInt(formatMetadataDataMap, field)?.let { metadataMap.putInt(field, it) }
+
+            "codecs", "sampleMimeType" ->
+              MapUtils.getString(formatMetadataDataMap, field)?.let { metadataMap.putString(field, it) }
+
+            /** List of fields available on `MediaMetadata`. */
+            "albumArtist", "albumTitle", "artist", "artworkData", "artworkDataType", "artworkUri",
+            "compilation", "composer", "conductor", "description", "displayTitle", "genre", "mediaType",
+            "station", "subtitle", "title", "writer" ->
+              MapUtils.getString(metadataDataMap, field)?.let { metadataMap.putString(field, it) }
+
+            "discNumber", "recordingDay", "recordingMonth", "recordingYear", "releaseDay", "releaseMonth",
+            "releaseYear", "totalDiscCount", "totalTrackCount", "trackNumber", "year" ->
+              MapUtils.getInt(metadataDataMap, field)?.let { metadataMap.putInt(field, it) }
+
+            "isBrowsable", "isPlayable" ->
+              MapUtils.getBoolean(metadataDataMap, field)?.let { metadataMap.putBoolean(field, it) }
+
+            "overallRating", "userRating" ->
+              MapUtils.getDouble(metadataDataMap, field)?.let { metadataMap.putDouble(field, it) }
+          }
+        }
+
+        // Compute bitrate using `MediaMetadataRetriever` if wanted and not found. Necessary for FLAC
+        // files as `Format` doesn't populate that field for whatever reason.
+        if (recheckBitRate) {
+          // Ensure the `MediaMetadataRetriever` uses the current URI.
+          if (mmrSource != uri) mmrMetadata.setDataSource(Normalization.getSafeUri(uri))
+          mmrMetadata.extractMetadata(MediaMetadataRetriever.METADATA_KEY_BITRATE)?.toIntOrNull()?.let { metadataMap.putInt("bitrate", it) }
+        }
+
+        // Have `albumArtist` fallback to `artist` value if it's not defined, but only when certain
+        // conditions are met (`artist` & `albumTitle` fields are defined).
+        if (metadataMap.hasKey("albumArtist") && metadataMap.isNull("albumArtist")) {
+          if (
+            metadataMap.hasKey("artist") && !metadataMap.isNull("artist") &&
+            metadataMap.hasKey("albumTitle") && !metadataMap.isNull("albumTitle")
           ) {
-          metadataMap.putString("albumArtist", metadataMap.getString("artist"))
+            metadataMap.putString("albumArtist", metadataMap.getString("artist"))
+          }
         }
-      }
 
-      promise.resolve(metadataMap)
-    } catch (e: ExecutionException) {
-      val isWantedException =
-        e.message?.contains("androidx.media3.datasource.FileDataSource\$FileDataSourceException")
-          ?: false
-      when (isWantedException) {
-        true -> promise.reject("ENOENT", "ENOENT: No such file or directory (${uri})", e)
-        false -> promise.reject("ERR_METADATA", e.message, e)
+        successArr.pushMap(ResultObject(uri, metadataMap))
+      } catch (e: ExecutionException) {
+        val isWantedException =
+          e.message?.contains("androidx.media3.datasource.FileDataSource\$FileDataSourceException")
+            ?: false
+        val errObj = ErrorObject(
+          if (isWantedException) "ENOENT" else "ERR_METADATA",
+          if (isWantedException) "ENOENT: No such file or directory (${uri})" else e.message ?: "",
+        )
+        errorArr.pushMap(ResultObject(uri, errObj))
+      } catch (e: Exception) {
+        errorArr.pushMap(ResultObject(uri, ErrorObject("ERR_METADATA", e.message ?: "")))
       }
-    } catch (e: Exception) {
-      promise.reject("ERR_METADATA", e.message, e)
-    } finally {
-      // Release `MediaMetadataRetriever` resources.
-      mmrMetadata?.release()
     }
+
+    // Release `MediaMetadataRetriever` resources.
+    mmrMetadata.release()
+
+    returnObj.putArray("success", successArr)
+    returnObj.putArray("error", errorArr)
+
+    promise.resolve(returnObj)
   }
 
   /**

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/models/BridgeReturnables.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/models/BridgeReturnables.kt
@@ -1,0 +1,18 @@
+package com.cyanchill.missingcore.metadataretriever.models.BridgeReturnables
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReadableMap
+
+fun ErrorObject(name: String, message: String): ReadableMap {
+  val value = Arguments.createMap()
+  value.putString("name", name)
+  value.putString("message", message)
+  return value
+}
+
+fun ResultObject(name: String, data: ReadableMap): ReadableMap {
+  val value = Arguments.createMap()
+  value.putString("uri", name)
+  value.putMap("data", data)
+  return value
+}

--- a/android/src/oldarch/MetadataRetrieverSpec.kt
+++ b/android/src/oldarch/MetadataRetrieverSpec.kt
@@ -8,7 +8,7 @@ import com.facebook.react.bridge.Promise
 
 abstract class MetadataRetrieverSpec internal constructor(context: ReactApplicationContext) :
   ReactContextBaseJavaModule(context) {
-  abstract fun getMetadata(uri: String, options: ReadableArray, promise: Promise)
+  abstract fun getBulkMetadata(uris: ReadableArray, options: ReadableArray, promise: Promise)
 
   abstract fun getArtwork(uri: String, promise: Promise)
 

--- a/examples/benchmarking-demo/App.tsx
+++ b/examples/benchmarking-demo/App.tsx
@@ -51,14 +51,14 @@ async function getTracks() {
     audioFiles.map(({ uri }) => uri),
     MetadataPresets.standardArtwork
   );
-  const tracksMetadata = results.success.map(({ uri, data }) => {
+  const tracksMetadata = results.results.map(({ uri, data }) => {
     const { id, filename } = assetURIMap[uri]!;
     return { id, filename, ...data };
   });
   console.log(
     `Got metadata of ${audioFiles.length} tracks in ${((performance.now() - start) / 1000).toFixed(4)}s.`
   );
-  console.log('Errors:', results.error);
+  console.log('Errors:', results.errors);
 
   return {
     duration: ((performance.now() - start) / 1000).toFixed(4),

--- a/examples/benchmarking-demo/App.tsx
+++ b/examples/benchmarking-demo/App.tsx
@@ -17,11 +17,9 @@ import {
 
 import {
   MetadataPresets,
-  getMetadata,
+  getBulkMetadata,
   updateConfigs,
 } from '@missingcore/react-native-metadata-retriever';
-
-import { isFulfilled, isRejected } from './utils/promise';
 
 const queryClient = new QueryClient();
 
@@ -45,22 +43,26 @@ async function getTracks() {
     `Got list of audio files in ${((performance.now() - start) / 1000).toFixed(4)}s.`
   );
 
-  const tracksMetadata = await Promise.allSettled(
-    audioFiles.map(async ({ id, filename, uri }) => {
-      const data = await getMetadata(uri, MetadataPresets.standardArtwork);
-      return { id, filename, ...data };
-    })
+  const assetURIMap = Object.fromEntries(
+    audioFiles.map((asset) => [asset.uri, asset])
   );
+
+  const results = await getBulkMetadata(
+    audioFiles.map(({ uri }) => uri),
+    MetadataPresets.standardArtwork
+  );
+  const tracksMetadata = results.success.map(({ uri, data }) => {
+    const { id, filename } = assetURIMap[uri]!;
+    return { id, filename, ...data };
+  });
   console.log(
     `Got metadata of ${audioFiles.length} tracks in ${((performance.now() - start) / 1000).toFixed(4)}s.`
   );
-
-  const errors = tracksMetadata.filter(isRejected).map(({ reason }) => reason);
-  console.log('Errors:', errors);
+  console.log('Errors:', results.error);
 
   return {
     duration: ((performance.now() - start) / 1000).toFixed(4),
-    tracks: tracksMetadata.filter(isFulfilled).map(({ value }) => value),
+    tracks: tracksMetadata,
   };
 }
 

--- a/examples/benchmarking-demo/utils/promise.ts
+++ b/examples/benchmarking-demo/utils/promise.ts
@@ -1,9 +1,0 @@
-/** Typeguard for finding promises that were fulfilled in `Promise.allsettled()`. */
-export const isFulfilled = <T>(
-  input: PromiseSettledResult<T>
-): input is PromiseFulfilledResult<T> => input.status === 'fulfilled';
-
-/** @description Typeguard for finding promises that were rejected in `Promise.allsettled()`. */
-export const isRejected = (
-  input: PromiseSettledResult<unknown>
-): input is PromiseRejectedResult => input.status === 'rejected';

--- a/src/NativeMetadataRetriever.ts
+++ b/src/NativeMetadataRetriever.ts
@@ -1,15 +1,21 @@
 import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';
 
+import type {
+  BulkMetadata,
+  ConfigOptions,
+  MediaMetadataPublicFields,
+} from './constants';
+
 export interface Spec extends TurboModule {
-  getMetadata(
-    uri: string,
-    options: readonly string[]
-  ): Promise<Record<string, unknown>>;
+  getBulkMetadata<TOptions extends MediaMetadataPublicFields>(
+    uris: string[],
+    options: TOptions
+  ): Promise<BulkMetadata<TOptions>>;
 
   getArtwork(uri: string): Promise<string | null>;
 
-  updateConfigs(options: Record<string, any>): Promise<void>;
+  updateConfigs(options: ConfigOptions): Promise<void>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('MetadataRetriever');

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -121,6 +121,13 @@ export type MediaMetadata = {
 export type MediaMetadataExcerpt<TKeys extends MediaMetadataPublicFields> =
   Prettify<Pick<MediaMetadata, TKeys[number]>>;
 
+type ResultObject<TData> = { uri: string; data: TData };
+
+export type BulkMetadata<TKeys extends MediaMetadataPublicFields> = {
+  success: Array<ResultObject<MediaMetadataExcerpt<TKeys>>>;
+  error: Array<ResultObject<{ name: string; message: string }>>;
+};
+
 export type ConfigOptions = {
   /**
    * Size of the returned base64 image in MB.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -124,8 +124,8 @@ export type MediaMetadataExcerpt<TKeys extends MediaMetadataPublicFields> =
 type ResultObject<TData> = { uri: string; data: TData };
 
 export type BulkMetadata<TKeys extends MediaMetadataPublicFields> = {
-  success: Array<ResultObject<MediaMetadataExcerpt<TKeys>>>;
-  error: Array<ResultObject<{ name: string; message: string }>>;
+  results: Array<ResultObject<MediaMetadataExcerpt<TKeys>>>;
+  errors: Array<ResultObject<{ name: string; message: string }>>;
 };
 
 export type ConfigOptions = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,13 +21,13 @@ export async function getMetadata<TOptions extends MediaMetadataPublicFields>(
   options: TOptions
 ): Promise<MediaMetadataExcerpt<TOptions>> {
   const result = await MetadataRetriever.getBulkMetadata([uri], options);
-  if (result.error.length) {
-    const { message, name } = result.error[0]!.data;
+  if (result.errors.length) {
+    const { message, name } = result.errors[0]!.data;
     const error = Error(message);
     error.name = name;
     throw error;
   }
-  return result.success[0]!.data;
+  return result.results[0]!.data;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,13 +9,25 @@ import type {
 import { MediaMetadataPublicFields, MetadataPresets } from './constants';
 
 /** Returns the specified metadata of a media file from its uri. */
+export async function getBulkMetadata<
+  TOptions extends MediaMetadataPublicFields,
+>(uris: string[], options: TOptions) {
+  return MetadataRetriever.getBulkMetadata(uris, options);
+}
+
+/** Returns the specified metadata of a media file from its uri. */
 export async function getMetadata<TOptions extends MediaMetadataPublicFields>(
   uri: string,
   options: TOptions
 ): Promise<MediaMetadataExcerpt<TOptions>> {
-  return MetadataRetriever.getMetadata(uri, options) as Promise<
-    MediaMetadataExcerpt<TOptions>
-  >;
+  const result = await MetadataRetriever.getBulkMetadata([uri], options);
+  if (result.error.length) {
+    const { message, name } = result.error[0]!.data;
+    const error = Error(message);
+    error.name = name;
+    throw error;
+  }
+  return result.success[0]!.data;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import MetadataRetriever from './MetadataRetriever';
 
 import type {
+  BulkMetadata,
   ConfigOptions,
   MediaMetadata,
   MediaMetadataExcerpt,
@@ -43,6 +44,7 @@ export async function updateConfigs(options: ConfigOptions): Promise<void> {
 }
 
 export {
+  type BulkMetadata,
   type ConfigOptions,
   type MediaMetadata,
   type MediaMetadataExcerpt,


### PR DESCRIPTION
This PR adds support for getting the metadata of multiple URIS at once with a new `getBulkMetadata` function.
- This function won't throw an error when encountered (unlike `getMetadata`). Instead, it returns an object with 2 fields, `results` & `errors`, each being an array containing objects with a `uri` & `data` field containing the result/error object.

We've also updated the example app to use `getBulkMetadata` instead of `getMetadata`.