### PR TITLE
feat: Option to save embedded artwork instead of returning a base64 string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,15 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
   - Customize the max size of the returned base64 image with the `maxImageSizeMB` option.
 - New `getBulkMetadata` function.
   - Slightly different than `getMetadata` as this function won't throw an error. It'll return an object with 2 fields, `results` & `errors` which contain an array of objects containing the URI & data/error associated with it.
+- New `saveArtwork` function.
+  - Allows the user to save the embedded artwork to a file and optionally compress it to save on space.
 
 ### ⚙️ Internal Changes
 
 - Reorganization of code.
   - Now "normalize" and put all the field-value pairs inside a map, which we then send the ones we want to return.
 - Ensure we release `MetadataRetriever` & `MediaMetadataRetriever` when we're done using them.
-- Updated example app to use `getBulkMetadata` instead of `getMetadata`.
+- Updated example app to use `getBulkMetadata` & `saveArtwork` instead of `getMetadata`.
 
 ## [1.1.0] - 2025-08-21
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ An object containing several metadata presets we can use to retrieve metadata.
 function getArtwork(uri: string): Promise<string | null>;
 ```
 
-Returns the base64 image string for the media file of the provided uri.
+Returns a base64 string representing the embedded artwork.
 
 > **Note:** Defaults to returning up to `5 MB` of data. Can be configured with [`updateConfigs`](#updateConfigs).
 
@@ -81,6 +81,17 @@ Returns the specified metadata of the provided uri based on the `options` argume
 
 > **Note:** The "complicated" typing is to make the resulting promise type-safe and be based off the provided `options`.
 
+### saveArtwork
+
+```ts
+function saveArtwork(
+  uri: string,
+  options?: ArtworkOptions
+): Promise<string | null>;
+```
+
+Returns the uri of the saved artwork.
+
 ### updateConfigs
 
 ```ts
@@ -90,6 +101,19 @@ function updateConfigs(options: ConfigOptions): Promise<void>;
 Update internal configuration options such as the max size of the returned base64 image.
 
 ## Types
+
+### ArtworkOptions
+
+```ts
+type ArtworkOptions = {
+  /** Uri we want to save the artwork to instead of the cache directory. */
+  saveUri?: string;
+  /** Whether we should compress the saved image to 80% image quality. */
+  compress?: boolean;
+};
+```
+
+Options to change the behavior of `saveArtwork`.
 
 ### BulkMetadata
 

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/MetadataRetrieverPackage.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/MetadataRetrieverPackage.kt
@@ -7,6 +7,7 @@ import com.facebook.react.module.model.ReactModuleInfoProvider
 import com.facebook.react.module.model.ReactModuleInfo
 import java.util.HashMap
 
+import com.cyanchill.missingcore.metadataretriever.modules.MetadataRetrieverModule
 
 class MetadataRetrieverPackage : TurboReactPackage() {
   override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? {

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataReader.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataReader.kt
@@ -1,6 +1,11 @@
 package com.cyanchill.missingcore.metadataretriever.modules
 
+import com.facebook.react.bridge.ReactApplicationContext
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.media.MediaMetadataRetriever
+import android.net.Uri
 import android.util.Base64
 import androidx.annotation.OptIn
 import androidx.media3.common.Format
@@ -9,13 +14,26 @@ import androidx.media3.common.PercentageRating
 import androidx.media3.common.Rating
 import androidx.media3.common.MediaMetadata as AndroidXMediaMetadata
 import androidx.media3.common.util.UnstableApi
+import java.io.File
+import java.io.FileOutputStream
 import java.net.URLConnection
+import java.util.UUID
 
 /**
  * Utilities to format & normalize sources of metadata as a map.
  */
 @OptIn(UnstableApi::class)
-class MetadataReader: APIConfigs() {
+class MetadataReader(reactContext: ReactApplicationContext): APIConfigs() {
+  private val saveDirectory = "${reactContext.cacheDir.absolutePath}${File.separator}MetadataRetriever"
+
+  /** Create `saveDirectory` if it doesn't exist. */
+  init {
+    try {
+      val directory = File(saveDirectory)
+      if (!directory.exists()) directory.mkdirs()
+    } catch (e: Exception) {}
+  }
+
   /**
    * Relevant metadata fields found on `Format`.
    *
@@ -103,7 +121,7 @@ class MetadataReader: APIConfigs() {
     val dataMap = hashMapOf<String, Any?>()
 
     // Pre-compute values to put in hash map.
-    val artworkData = if (getArtworkData) getBase64Image(mmr.getEmbeddedPicture()) else null
+    val artworkData = if (getArtworkData) getBase64Image(mmr.embeddedPicture) else null
     val trackNumber = mmr.extractMetadata(MediaMetadataRetriever.METADATA_KEY_CD_TRACK_NUMBER)
       ?.let { if (it.toIntOrNull() == 0) null else it.toIntOrNull() }
     val year = parseYear(mmr.extractMetadata(MediaMetadataRetriever.METADATA_KEY_YEAR)) ?: run {
@@ -111,7 +129,7 @@ class MetadataReader: APIConfigs() {
         // The "date" format should start with 4 digits representing the year.
         parseYear(mmr.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DATE))
           ?.let { if (it > 999) it else null }
-      } catch (err: Exception) {
+      } catch (e: Exception) {
         null
       }
     }
@@ -153,6 +171,26 @@ class MetadataReader: APIConfigs() {
     val maxSizeBytes = maxSizeMB * 0.75 * 1024 * 1024
     if (bytes.size > maxSizeBytes) return null
     return "data:$mimeType;base64,${Base64.encodeToString(bytes, Base64.DEFAULT)}"
+  }
+
+  /** Save `ByteArray` as image, returning the URI if it was saved correctly. */
+  fun saveImage(bytes: ByteArray, savePath: String? = null, compress: Boolean = false): String? {
+    try {
+      // Generate path to save image if we didn't provide one.
+      val imgUri = savePath ?: "$saveDirectory${File.separator}${UUID.randomUUID()}.jpeg"
+      val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+      FileOutputStream(imgUri).use { fos ->
+        bitmap.compress(
+          Bitmap.CompressFormat.JPEG,
+          if (compress) 80 else 100,
+          fos,
+        )
+        fos.flush()
+      }
+      return Uri.fromFile(File(imgUri)).toString()
+    } catch (e: Exception) {
+      return null
+    }
   }
   //#endregion
 

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataRetrieverModule.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataRetrieverModule.kt
@@ -30,7 +30,7 @@ class MetadataRetrieverModule internal constructor(reactContext: ReactApplicatio
   MetadataRetrieverSpec(reactContext) {
   private val context = reactContext
 
-  private var reader = MetadataReader()
+  private var reader = MetadataReader(reactContext)
 
   @ReactMethod
   override fun getBulkMetadata(uris: ReadableArray, options: ReadableArray, promise: Promise) {
@@ -172,7 +172,7 @@ class MetadataRetrieverModule internal constructor(reactContext: ReactApplicatio
       if (metadataList.isEmpty()) {
         val mmrMetadata = MediaMetadataRetriever()
         mmrMetadata.setDataSource(Normalization.getSafeUri(uri))
-        promise.resolve(reader.getBase64Image(mmrMetadata.getEmbeddedPicture()))
+        promise.resolve(reader.getBase64Image(mmrMetadata.embeddedPicture))
         mmrMetadata.release()
         return
       }
@@ -216,6 +216,77 @@ class MetadataRetrieverModule internal constructor(reactContext: ReactApplicatio
       }
 
       promise.resolve(coverImage ?: backupImage)
+    } catch (e: ExecutionException) {
+      val isWantedException =
+        e.message?.contains("androidx.media3.datasource.FileDataSource\$FileDataSourceException")
+          ?: false
+      when (isWantedException) {
+        true -> promise.reject("ENOENT", "ENOENT: No such file or directory (${uri})", e)
+        false -> promise.reject("ERR_ARTWORK", e.message, e)
+      }
+    } catch (e: Exception) {
+      promise.reject("ERR_ARTWORK", e.message, e)
+    }
+  }
+
+  /** Saves artwork to specified URI or cache directory. */
+  @ReactMethod
+  override fun saveArtwork(uri: String, options: ReadableMap, promise: Promise) {
+    val optionsBundle = Arguments.toBundle(options) as Bundle
+    val saveUri = optionsBundle.getString("saveUri")
+    val compress = optionsBundle.getBoolean("compress")
+
+    try {
+      val metadataList = getMetadataList(getFormatList(uri))
+
+      // We'll want to return the image designated as "Cover (front)", otherwise return image for
+      // "32x32 pixels 'file icon' (PNG only)" or "Other".
+      var coverImage: ByteArray? = null
+      var backupImage: ByteArray? = null
+      var backupImageCode: Int? = null
+
+      // Fallback to `MediaMetadataRetriever` if we find nothing with `MetadataRetriever`.
+      if (metadataList.isEmpty()) {
+        val mmrMetadata = MediaMetadataRetriever()
+        mmrMetadata.setDataSource(Normalization.getSafeUri(uri))
+        coverImage = mmrMetadata.embeddedPicture
+        mmrMetadata.release()
+      }
+
+      for (metadataItem in metadataList) {
+        val mediaMetadata = MediaMetadata.Builder()
+          .populateFromMetadata(metadataItem)
+          .build()
+
+        when (mediaMetadata.artworkDataType) {
+          // "Other" Picture Type
+          MediaMetadata.PICTURE_TYPE_OTHER -> {
+            if (backupImage == null || backupImageCode == 1) {
+              val newImg = mediaMetadata.artworkData
+              if (newImg !== null) {
+                backupImage = newImg
+                backupImageCode = 3
+              }
+            }
+          }
+          // "32x32 pixels 'file icon' (PNG only)" Picture Type
+          MediaMetadata.PICTURE_TYPE_FILE_ICON -> {
+            if (backupImage == null) {
+              backupImage = mediaMetadata.artworkData
+              backupImageCode = 1
+            }
+          }
+          // "Cover (front)" Picture Type
+          MediaMetadata.PICTURE_TYPE_FRONT_COVER -> {
+            coverImage = mediaMetadata.artworkData
+          }
+        }
+
+        if (coverImage !== null) break
+      }
+
+      val imgUri = (coverImage ?: backupImage)?.let { reader.saveImage(it, saveUri, compress) }
+      promise.resolve(imgUri)
     } catch (e: ExecutionException) {
       val isWantedException =
         e.message?.contains("androidx.media3.datasource.FileDataSource\$FileDataSourceException")

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataRetrieverModule.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataRetrieverModule.kt
@@ -162,77 +162,13 @@ class MetadataRetrieverModule internal constructor(reactContext: ReactApplicatio
    * Get artwork of audio file from its uri. Unlike getting the artwork from `getMetadata()`, whose
    * artwork is based on the last `artworkData` found, `getArtwork()` returns the artwork designated
    * as "Cover (front)" and falls back to "Other".
+   *
+   * Either returns the URI to the saved artwork or a base64 image string.
    */
   @ReactMethod
-  override fun getArtwork(uri: String, promise: Promise) {
-    try {
-      val metadataList = getMetadataList(getFormatList(uri))
-
-      // Fallback to `MediaMetadataRetriever` if we find nothing with `MetadataRetriever`.
-      if (metadataList.isEmpty()) {
-        val mmrMetadata = MediaMetadataRetriever()
-        mmrMetadata.setDataSource(Normalization.getSafeUri(uri))
-        promise.resolve(reader.getBase64Image(mmrMetadata.embeddedPicture))
-        mmrMetadata.release()
-        return
-      }
-
-      // We'll want to return the image designated as "Cover (front)", otherwise return image for
-      // "32x32 pixels 'file icon' (PNG only)" or "Other".
-      var coverImage: String? = null
-      var backupImage: String? = null
-      var backupImageCode: Int? = null
-
-      for (metadataItem in metadataList) {
-        val mediaMetadata = MediaMetadata.Builder()
-          .populateFromMetadata(metadataItem)
-          .build()
-
-        when (mediaMetadata.artworkDataType) {
-          // "Other" Picture Type
-          MediaMetadata.PICTURE_TYPE_OTHER -> {
-            if (backupImage == null || backupImageCode == 1) {
-              val newImg = reader.getBase64Image(mediaMetadata.artworkData)
-              if (newImg !== null) {
-                backupImage = newImg
-                backupImageCode = 3
-              }
-            }
-          }
-          // "32x32 pixels 'file icon' (PNG only)" Picture Type
-          MediaMetadata.PICTURE_TYPE_FILE_ICON -> {
-            if (backupImage == null) {
-              backupImage = reader.getBase64Image(mediaMetadata.artworkData)
-              backupImageCode = 1
-            }
-          }
-          // "Cover (front)" Picture Type
-          MediaMetadata.PICTURE_TYPE_FRONT_COVER -> {
-            coverImage = reader.getBase64Image(mediaMetadata.artworkData)
-          }
-        }
-
-        if (coverImage !== null) break
-      }
-
-      promise.resolve(coverImage ?: backupImage)
-    } catch (e: ExecutionException) {
-      val isWantedException =
-        e.message?.contains("androidx.media3.datasource.FileDataSource\$FileDataSourceException")
-          ?: false
-      when (isWantedException) {
-        true -> promise.reject("ENOENT", "ENOENT: No such file or directory (${uri})", e)
-        false -> promise.reject("ERR_ARTWORK", e.message, e)
-      }
-    } catch (e: Exception) {
-      promise.reject("ERR_ARTWORK", e.message, e)
-    }
-  }
-
-  /** Saves artwork to specified URI or cache directory. */
-  @ReactMethod
-  override fun saveArtwork(uri: String, options: ReadableMap, promise: Promise) {
+  override fun getArtwork(uri: String, options: ReadableMap, promise: Promise) {
     val optionsBundle = Arguments.toBundle(options) as Bundle
+    val asBase64 = optionsBundle.getBoolean("base64")
     val saveUri = optionsBundle.getString("saveUri")
     val compress = optionsBundle.getBoolean("compress")
 
@@ -241,15 +177,15 @@ class MetadataRetrieverModule internal constructor(reactContext: ReactApplicatio
 
       // We'll want to return the image designated as "Cover (front)", otherwise return image for
       // "32x32 pixels 'file icon' (PNG only)" or "Other".
-      var coverImage: ByteArray? = null
-      var backupImage: ByteArray? = null
+      var coverImage: Any? = null
+      var backupImage: Any? = null
       var backupImageCode: Int? = null
 
       // Fallback to `MediaMetadataRetriever` if we find nothing with `MetadataRetriever`.
       if (metadataList.isEmpty()) {
         val mmrMetadata = MediaMetadataRetriever()
         mmrMetadata.setDataSource(Normalization.getSafeUri(uri))
-        coverImage = mmrMetadata.embeddedPicture
+        coverImage = if (asBase64) reader.getBase64Image(mmrMetadata.embeddedPicture) else mmrMetadata.embeddedPicture
         mmrMetadata.release()
       }
 
@@ -262,7 +198,7 @@ class MetadataRetrieverModule internal constructor(reactContext: ReactApplicatio
           // "Other" Picture Type
           MediaMetadata.PICTURE_TYPE_OTHER -> {
             if (backupImage == null || backupImageCode == 1) {
-              val newImg = mediaMetadata.artworkData
+              val newImg = if (asBase64) reader.getBase64Image(mediaMetadata.artworkData) else mediaMetadata.artworkData
               if (newImg !== null) {
                 backupImage = newImg
                 backupImageCode = 3
@@ -272,21 +208,26 @@ class MetadataRetrieverModule internal constructor(reactContext: ReactApplicatio
           // "32x32 pixels 'file icon' (PNG only)" Picture Type
           MediaMetadata.PICTURE_TYPE_FILE_ICON -> {
             if (backupImage == null) {
-              backupImage = mediaMetadata.artworkData
+              backupImage = if (asBase64) reader.getBase64Image(mediaMetadata.artworkData) else mediaMetadata.artworkData
               backupImageCode = 1
             }
           }
           // "Cover (front)" Picture Type
           MediaMetadata.PICTURE_TYPE_FRONT_COVER -> {
-            coverImage = mediaMetadata.artworkData
+            coverImage = if (asBase64) reader.getBase64Image(mediaMetadata.artworkData) else mediaMetadata.artworkData
           }
         }
 
         if (coverImage !== null) break
       }
 
-      val imgUri = (coverImage ?: backupImage)?.let { reader.saveImage(it, saveUri, compress) }
-      promise.resolve(imgUri)
+      if (asBase64) {
+        // `coverImage` or `backupImage` should be a base64 string or `null`.
+        promise.resolve(coverImage ?: backupImage)
+      } else {
+        val imgUri = (coverImage ?: backupImage)?.let { reader.saveImage(it as ByteArray, saveUri, compress) }
+        promise.resolve(imgUri)
+      }
     } catch (e: ExecutionException) {
       val isWantedException =
         e.message?.contains("androidx.media3.datasource.FileDataSource\$FileDataSourceException")

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataRetrieverModule.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataRetrieverModule.kt
@@ -1,4 +1,4 @@
-package com.cyanchill.missingcore.metadataretriever
+package com.cyanchill.missingcore.metadataretriever.modules
 
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
@@ -19,8 +19,8 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.MetadataRetriever
 import java.util.concurrent.ExecutionException
 
+import com.cyanchill.missingcore.metadataretriever.MetadataRetrieverSpec
 import com.cyanchill.missingcore.metadataretriever.models.BridgeReturnables.*
-import com.cyanchill.missingcore.metadataretriever.modules.MetadataReader
 import com.cyanchill.missingcore.metadataretriever.utils.MapUtils
 import com.cyanchill.missingcore.metadataretriever.utils.Normalization
 

--- a/android/src/oldarch/MetadataRetrieverSpec.kt
+++ b/android/src/oldarch/MetadataRetrieverSpec.kt
@@ -11,6 +11,7 @@ abstract class MetadataRetrieverSpec internal constructor(context: ReactApplicat
   abstract fun getBulkMetadata(uris: ReadableArray, options: ReadableArray, promise: Promise)
 
   abstract fun getArtwork(uri: String, promise: Promise)
+  abstract fun saveArtwork(uri: String, options: ReadableMap, promise: Promise)
 
   abstract fun updateConfigs(options: ReadableMap, promise: Promise)
 }

--- a/android/src/oldarch/MetadataRetrieverSpec.kt
+++ b/android/src/oldarch/MetadataRetrieverSpec.kt
@@ -10,8 +10,7 @@ abstract class MetadataRetrieverSpec internal constructor(context: ReactApplicat
   ReactContextBaseJavaModule(context) {
   abstract fun getBulkMetadata(uris: ReadableArray, options: ReadableArray, promise: Promise)
 
-  abstract fun getArtwork(uri: String, promise: Promise)
-  abstract fun saveArtwork(uri: String, options: ReadableMap, promise: Promise)
+  abstract fun getArtwork(uri: String, options: ReadableMap, promise: Promise)
 
   abstract fun updateConfigs(options: ReadableMap, promise: Promise)
 }

--- a/examples/benchmarking-demo/App.tsx
+++ b/examples/benchmarking-demo/App.tsx
@@ -18,8 +18,11 @@ import {
 import {
   MetadataPresets,
   getBulkMetadata,
+  saveArtwork,
   updateConfigs,
 } from '@missingcore/react-native-metadata-retriever';
+
+import { isFulfilled } from './utils/promise';
 
 const queryClient = new QueryClient();
 
@@ -49,12 +52,15 @@ async function getTracks() {
 
   const results = await getBulkMetadata(
     audioFiles.map(({ uri }) => uri),
-    MetadataPresets.standardArtwork
+    MetadataPresets.standard
   );
-  const tracksMetadata = results.results.map(({ uri, data }) => {
-    const { id, filename } = assetURIMap[uri]!;
-    return { id, filename, ...data };
-  });
+  const tracksMetadata = await Promise.allSettled(
+    results.results.map(async ({ uri, data }) => {
+      const { id, filename } = assetURIMap[uri]!;
+      const imgUri = await saveArtwork(uri, { compress: true });
+      return { id, filename, artworkData: imgUri, ...data };
+    })
+  );
   console.log(
     `Got metadata of ${audioFiles.length} tracks in ${((performance.now() - start) / 1000).toFixed(4)}s.`
   );
@@ -62,7 +68,7 @@ async function getTracks() {
 
   return {
     duration: ((performance.now() - start) / 1000).toFixed(4),
-    tracks: tracksMetadata,
+    tracks: tracksMetadata.filter(isFulfilled).map(({ value }) => value),
   };
 }
 

--- a/examples/benchmarking-demo/utils/promise.ts
+++ b/examples/benchmarking-demo/utils/promise.ts
@@ -1,0 +1,9 @@
+/** Typeguard for finding promises that were fulfilled in `Promise.allsettled()`. */
+export const isFulfilled = <T>(
+  input: PromiseSettledResult<T>
+): input is PromiseFulfilledResult<T> => input.status === 'fulfilled';
+
+/** @description Typeguard for finding promises that were rejected in `Promise.allsettled()`. */
+export const isRejected = (
+  input: PromiseSettledResult<unknown>
+): input is PromiseRejectedResult => input.status === 'rejected';

--- a/src/NativeMetadataRetriever.ts
+++ b/src/NativeMetadataRetriever.ts
@@ -1,6 +1,7 @@
 import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';
 
+import type { ArtworkOptions } from './types/ArtworkOptions';
 import type { ConfigOptions } from './types/ConfigOptions';
 import type { BulkMetadata } from './types/GetMetadata';
 import type { MediaMetadataPublicFields } from './types/MediaMetadataPublicField';
@@ -11,7 +12,10 @@ export interface Spec extends TurboModule {
     options: TOptions
   ): Promise<BulkMetadata<TOptions>>;
 
-  getArtwork(uri: string): Promise<string | null>;
+  getArtwork(
+    uri: string,
+    options: ArtworkOptions & { base64?: boolean }
+  ): Promise<string | null>;
 
   updateConfigs(options: ConfigOptions): Promise<void>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import MetadataRetriever from './MetadataRetriever';
 
 import { MetadataPresets } from './constants';
 
+import type { ArtworkOptions } from './types/ArtworkOptions';
 import type { ConfigOptions } from './types/ConfigOptions';
 import type { BulkMetadata, MediaMetadataExcerpt } from './types/GetMetadata';
 import type { MediaMetadata } from './types/MediaMetadata';
@@ -33,11 +34,19 @@ export async function getMetadata<TOptions extends MediaMetadataPublicFields>(
 }
 
 /**
- * Returns the artwork of the specified media file from its uri.
+ * Returns a base64 string representing the embedded artwork.
  * - Defaults to returning up to `5 MB` of data.
  */
 export async function getArtwork(uri: string): Promise<string | null> {
-  return MetadataRetriever.getArtwork(uri);
+  return MetadataRetriever.getArtwork(uri, { base64: true });
+}
+
+/** Returns the uri of the saved artwork. */
+export async function saveArtwork(
+  uri: string,
+  options?: ArtworkOptions
+): Promise<string | null> {
+  return MetadataRetriever.getArtwork(uri, options ?? {});
 }
 
 export async function updateConfigs(options: ConfigOptions): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ export async function updateConfigs(options: ConfigOptions): Promise<void> {
 }
 
 export {
+  type ArtworkOptions,
   type BulkMetadata,
   type ConfigOptions,
   type MediaMetadata,

--- a/src/types/ArtworkOptions.ts
+++ b/src/types/ArtworkOptions.ts
@@ -1,0 +1,7 @@
+/** Extra options for when using `getArtwork`. */
+export type ArtworkOptions = {
+  /** Uri we want to save the artwork to instead of the cache directory. */
+  saveUri?: string;
+  /** Whether we should compress the saved image to 80% image quality. */
+  compress?: boolean;
+};


### PR DESCRIPTION
This PR adds a new `saveArtwork` function which gives an alternative way of getting an embedded artwork. Instead of returning a base64 string, we can get the URI of where that image was saved to.
- By default, the embedded artwork will be saved to the app's cache folder.
  - Since we're saving to the app's cache folder, no additional permissions should be needed.
- We can specify the location we want to save the image with the `saveUri` option.
- We can save the image at 80% quality by adding the `compress` boolean option.

### Other Changes
- Moved `MetadataRetrieverModule` to the `modules` folder.
- Updated example to use `saveArtwork`.
