### PR TITLE
feat: New `getLyric()` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### 🎉 Added
+
+- New `getLyric()` function that attempts to return the embedded lyrics for a track.
+
 ## [3.0.0-beta.1] - 2026-03-18
 
 ### ❗ Breaking Changes

--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ function getBulkMetadata<TOptions extends MediaMetadataPublicFields>(
 
 Get the metadata of multiple uris.
 
+### getLyric
+
+```ts
+function getLyric(uri: string): Promise<string | null>;
+```
+
+Attempts to return the embedded lyrics for a track.
+
 ### getMetadata
 
 ```ts

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataRetrieverModule.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataRetrieverModule.kt
@@ -225,6 +225,42 @@ class MetadataRetrieverModule(reactContext: ReactApplicationContext) :
     }
   }
 
+  /** Returns embedded lyrics in supported "lyrics" tags. Prefers returning synchronized lyrics. */
+  override fun getLyric(uri: String, promise: Promise) {
+    try {
+      val metadataList = getMetadataList(getFormatList(uri))
+
+      var syncLyrics: String? = null
+      var unsyncLyrics: String? = null
+
+      for (metadata in metadataList) {
+        val numEntries = metadata.length()
+        // Manually iterate over metadata entries to find a supported key.
+        for (i in 0 until numEntries) {
+          val metadataEntry = metadata[i].toString()
+
+          if (metadataEntry.contains(VORBIS_LYRICS_TAG)) {
+            syncLyrics = metadataEntry.split(VORBIS_LYRICS_TAG)[1]
+          }
+
+          if (syncLyrics !== null) break
+        }
+      }
+
+      promise.resolve(syncLyrics ?: unsyncLyrics)
+    } catch (e: ExecutionException) {
+      val isWantedException =
+        e.message?.contains("androidx.media3.datasource.FileDataSource\$FileDataSourceException")
+          ?: false
+      when (isWantedException) {
+        true -> promise.reject("ENOENT", "ENOENT: No such file or directory (${uri})", e)
+        false -> promise.reject("ERR_LYRIC", e.message, e)
+      }
+    } catch (e: Exception) {
+      promise.reject("ERR_LYRIC", e.message, e)
+    }
+  }
+
   /** Expose to the user the ability to update internal configuration options. */
   override fun updateConfigs(options: ReadableMap, promise: Promise) {
     reader.updateConfigs(Arguments.toBundle(options) as Bundle)
@@ -270,5 +306,7 @@ class MetadataRetrieverModule(reactContext: ReactApplicationContext) :
 
   companion object {
     const val NAME = NativeMetadataRetrieverSpec.NAME
+
+    private const val VORBIS_LYRICS_TAG = "VC: LYRICS="
   }
 }

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataRetrieverModule.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataRetrieverModule.kt
@@ -9,6 +9,9 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Metadata
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.extractor.metadata.id3.BinaryFrame
+import androidx.media3.extractor.metadata.id3.TextInformationFrame
+import androidx.media3.extractor.metadata.vorbis.VorbisComment
 import androidx.media3.inspector.MetadataRetriever
 import com.cyanchill.missingcore.metadataretriever.NativeMetadataRetrieverSpec
 import com.cyanchill.missingcore.metadataretriever.models.ArtworkOptions
@@ -20,6 +23,7 @@ import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.ExecutionException
 
 @OptIn(UnstableApi::class)
@@ -230,29 +234,35 @@ class MetadataRetrieverModule(reactContext: ReactApplicationContext) :
     try {
       val metadataList = getMetadataList(getFormatList(uri))
 
-      var syncLyrics: String? = null
-      var unsyncLyrics: String? = null
+      var lyricsStr: String? = null
+      var isLyricsSync = false
 
       for (metadata in metadataList) {
         val numEntries = metadata.length()
         // Manually iterate over metadata entries to find a supported key.
         for (i in 0 until numEntries) {
-          val metadataEntry = metadata[i].toString()
+          val metadataEntry = metadata[i]
 
-          if (metadataEntry.contains(VORBIS_LYRICS_TAG)) {
-            syncLyrics = metadataEntry.split(VORBIS_LYRICS_TAG)[1]
-          } else if (metadataEntry.startsWith(ID3_LYRICS_UNSYNC_TAG)) {
-            // Lyrics are put inside `values=[]`.
-            unsyncLyrics = metadataEntry.split("values=[")[1].dropLast(1)
-          } else if (metadataEntry.startsWith(ID3_LYRICS_SYNC_TAG)) {
-            syncLyrics = metadataEntry.split("values=[")[1].dropLast(1)
+          if (metadataEntry is VorbisComment && metadataEntry.key.uppercase() == "LYRICS") {
+            lyricsStr = metadataEntry.value
+            isLyricsSync = true
+          } else if (
+            (metadataEntry is TextInformationFrame || metadataEntry is BinaryFrame) &&
+            metadataEntry.id.uppercase() in ID3v2_LYRIC_TAGS
+          ) {
+            lyricsStr = when(metadataEntry) {
+              is TextInformationFrame -> metadataEntry.values[0]
+              is BinaryFrame -> String(metadataEntry.data, StandardCharsets.UTF_8)
+              else -> null
+            }
+            isLyricsSync = metadataEntry.id.uppercase() === "SYLT"
           }
 
-          if (syncLyrics !== null) break
+          if (isLyricsSync) break
         }
       }
 
-      promise.resolve(syncLyrics ?: unsyncLyrics)
+      promise.resolve(lyricsStr)
     } catch (e: ExecutionException) {
       val isWantedException =
         e.message?.contains("androidx.media3.datasource.FileDataSource\$FileDataSourceException")
@@ -312,8 +322,7 @@ class MetadataRetrieverModule(reactContext: ReactApplicationContext) :
   companion object {
     const val NAME = NativeMetadataRetrieverSpec.NAME
 
-    private const val ID3_LYRICS_UNSYNC_TAG = "USLT:"
-    private const val ID3_LYRICS_SYNC_TAG = "SYLT:"
-    private const val VORBIS_LYRICS_TAG = "VC: LYRICS="
+    // We'll only support embedded lyrics in ID3v2.3+ tags.
+    private val ID3v2_LYRIC_TAGS = listOf("SYLT", "USLT")
   }
 }

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataRetrieverModule.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataRetrieverModule.kt
@@ -23,7 +23,6 @@ import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
-import java.nio.charset.StandardCharsets
 import java.util.concurrent.ExecutionException
 
 @OptIn(UnstableApi::class)
@@ -250,9 +249,21 @@ class MetadataRetrieverModule(reactContext: ReactApplicationContext) :
             (metadataEntry is TextInformationFrame || metadataEntry is BinaryFrame) &&
             metadataEntry.id.uppercase() in ID3v2_LYRIC_TAGS
           ) {
-            lyricsStr = when(metadataEntry) {
+            lyricsStr = when (metadataEntry) {
               is TextInformationFrame -> metadataEntry.values[0]
-              is BinaryFrame -> String(metadataEntry.data, StandardCharsets.UTF_8)
+              is BinaryFrame -> {
+                // The 1st byte in the array determines the encoding in ID3.
+                //  - Mp3Tag doesn't specify a Byte Order Mark if it's `1` (UTF-16), so we'll assume
+                //  it's UTF-16LE.
+                //  - Ref: https://mutagen-specs.readthedocs.io/en/latest/id3/id3v2.4.0-structure.html#id3v2-frame-overview
+                val encodingCharSet = when (metadataEntry.data[0].toString()) {
+                  "0" -> Charsets.ISO_8859_1
+                  "1" -> Charsets.UTF_16LE
+                  "2" -> Charsets.UTF_16BE
+                  else -> Charsets.UTF_8
+                }
+                String(metadataEntry.data, encodingCharSet)
+              }
               else -> null
             }
             isLyricsSync = metadataEntry.id.uppercase() === "SYLT"

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataRetrieverModule.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataRetrieverModule.kt
@@ -241,6 +241,11 @@ class MetadataRetrieverModule(reactContext: ReactApplicationContext) :
 
           if (metadataEntry.contains(VORBIS_LYRICS_TAG)) {
             syncLyrics = metadataEntry.split(VORBIS_LYRICS_TAG)[1]
+          } else if (metadataEntry.startsWith(ID3_LYRICS_UNSYNC_TAG)) {
+            // Lyrics are put inside `values=[]`.
+            unsyncLyrics = metadataEntry.split("values=[")[1].dropLast(1)
+          } else if (metadataEntry.startsWith(ID3_LYRICS_SYNC_TAG)) {
+            syncLyrics = metadataEntry.split("values=[")[1].dropLast(1)
           }
 
           if (syncLyrics !== null) break
@@ -307,6 +312,8 @@ class MetadataRetrieverModule(reactContext: ReactApplicationContext) :
   companion object {
     const val NAME = NativeMetadataRetrieverSpec.NAME
 
+    private const val ID3_LYRICS_UNSYNC_TAG = "USLT:"
+    private const val ID3_LYRICS_SYNC_TAG = "SYLT:"
     private const val VORBIS_LYRICS_TAG = "VC: LYRICS="
   }
 }

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataRetrieverModule.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataRetrieverModule.kt
@@ -252,17 +252,29 @@ class MetadataRetrieverModule(reactContext: ReactApplicationContext) :
             lyricsStr = when (metadataEntry) {
               is TextInformationFrame -> metadataEntry.values[0]
               is BinaryFrame -> {
+                val byteArr = metadataEntry.data
                 // The 1st byte in the array determines the encoding in ID3.
                 //  - Mp3Tag doesn't specify a Byte Order Mark if it's `1` (UTF-16), so we'll assume
                 //  it's UTF-16LE.
                 //  - Ref: https://mutagen-specs.readthedocs.io/en/latest/id3/id3v2.4.0-structure.html#id3v2-frame-overview
-                val encodingCharSet = when (metadataEntry.data[0].toString()) {
+                val encodingCharSet = when (byteArr[0].toString()) {
                   "0" -> Charsets.ISO_8859_1
-                  "1" -> Charsets.UTF_16LE
+                  "1" -> {
+                    if (byteArr[1] == BYTE_0xFE && byteArr[2] == BYTE_0xFF) {
+                      Charsets.UTF_16BE
+                    } else if (byteArr[1] == BYTE_0xFF && byteArr[2] == BYTE_0xFE) {
+                      Charsets.UTF_16LE
+                    } else {
+                      // Heuristic guess of byte order using new line character.
+                      //  - If the conversion contains a newline character, that charset should be used.
+                      if (String(byteArr, Charsets.UTF_16LE).contains("\n")) Charsets.UTF_16LE
+                      else Charsets.UTF_16BE
+                    }
+                  }
                   "2" -> Charsets.UTF_16BE
                   else -> Charsets.UTF_8
                 }
-                String(metadataEntry.data, encodingCharSet)
+                String(byteArr, encodingCharSet)
               }
               else -> null
             }
@@ -335,5 +347,7 @@ class MetadataRetrieverModule(reactContext: ReactApplicationContext) :
 
     // We'll only support embedded lyrics in ID3v2.3+ tags.
     private val ID3v2_LYRIC_TAGS = listOf("SYLT", "USLT")
+    private const val BYTE_0xFE = 0xFE.toByte()
+    private const val BYTE_0xFF = 0xFF.toByte()
   }
 }

--- a/src/NativeMetadataRetriever.ts
+++ b/src/NativeMetadataRetriever.ts
@@ -45,6 +45,8 @@ export interface Spec extends TurboModule {
     options: ArtworkOptions & { base64?: boolean }
   ): Promise<string | null>;
 
+  getLyric(uri: string): Promise<string | null>;
+
   updateConfigs(options: ConfigOptions): Promise<void>;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import type {
   MediaMetadataPublicFields,
 } from './types/MediaMetadataPublicField';
 
+//#region Get Metadata
 /** Get the metadata from multiple uris. */
 export async function getBulkMetadata<
   TOptions extends MediaMetadataPublicFields,
@@ -39,7 +40,9 @@ export async function getMetadata<TOptions extends MediaMetadataPublicFields>(
   }
   return result.results[0]!.data;
 }
+//#endregion
 
+//#region Get Artwork
 /**
  * Returns a base64 string representing the embedded artwork.
  * - Defaults to returning up to `5 MB` of data.
@@ -58,11 +61,21 @@ export async function saveArtwork(
 ): Promise<string | null> {
   return MetadataRetriever.getArtwork(uri, options ?? {});
 }
+//#endregion
 
+//#region Get Lyric
+/** Attempts to return the embedded lyrics. */
+export async function getLyric(uri: string): Promise<string | null> {
+  return MetadataRetriever.getLyric(uri);
+}
+//#endregion
+
+//#region Configuration
 /** Update internal configuration options. */
 export async function updateConfigs(options: ConfigOptions): Promise<void> {
   return MetadataRetriever.updateConfigs(options);
 }
+//#endregion
 
 export {
   type ArtworkOptions,


### PR DESCRIPTION
This PR adds a new `getLyric()` function which attempts to get the embedded lyrics for a track from its URI.

From our tests, it should work with `USLT` tags for ID3, `LYRICS` tag for Vorbis Comments, and `©lyr` tag for MP4.
- One interesting thing about the MP4 lyric tag is that it gets converted to a `TextInformationFrame` based on [the MP4 metadata extractor code in the media3 repository](https://github.com/androidx/media/blob/7ce3aa2619b19009e4799319b4dd694a4a7577df/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/MetadataUtil.java#L171-L172) (with the ["tag" being stored as a hexadecimal](https://github.com/androidx/media/blob/7ce3aa2619b19009e4799319b4dd694a4a7577df/libraries/extractor/src/main/java/androidx/media3/extractor/mp4/MetadataUtil.java#L54)).

We initially tried to parse through the stringified `Metadata` object, but encountered issues with the `USLT` tag for MP3. We ended up [following this approach](https://redirect.github.com/androidx/media/issues/922), which proved more reliable and fixed the issue with the prior method not working with MP3 files due to the data for `USLT` being a "Binary Frame".
- We still had some issues with incorrect encoding of some characters (most notably with a ID3v2.3 file with Chinese characters), which was resulted in passing the incorrect charset when converting the byte array to a string.
- For ID3, the [1st byte indicates the encoding method](https://mutagen-specs.readthedocs.io/en/latest/id3/id3v2.4.0-structure.html#id3v2-frame-overview). For ID3v2.3, it would return 1, but the problem was that there wasn't any Byte Order Mark (BOM) in the following 2 bytes.
- From random testing, we got the embedded lyrics with Chinese characters to display correctly with UTF-16LE, which kind of makes sense as we used Mp3Tag on Windows, which defaults to UTF-16LE for this.

