### PR TITLE
feat: New `getR128Gain` function to get track replay gain value

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ Returns the specified metadata of the provided uri based on the `options` argume
 
 > **Note:** The "complicated" typing is to make the resulting promise type-safe and be based off the provided `options`.
 
+### getR128Gain
+
+```ts
+function getR128Gain(uri: string): Promise<number | null>;
+```
+
+Attempts to return the track replay gain.
+
 ### saveArtwork
 
 ```ts

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataRetrieverModule.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataRetrieverModule.kt
@@ -251,7 +251,7 @@ class MetadataRetrieverModule(reactContext: ReactApplicationContext) :
             metadataEntry.id.uppercase() in ID3v2_LYRIC_TAGS
           ) {
             lyricsStr = when (metadataEntry) {
-              is TextInformationFrame -> metadataEntry.values[0]
+              is TextInformationFrame -> metadataEntry.values.firstOrNull()
               is BinaryFrame -> {
                 val byteArr = metadataEntry.data
                 // The 1st byte in the array determines the encoding in ID3.

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataRetrieverModule.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataRetrieverModule.kt
@@ -315,7 +315,7 @@ class MetadataRetrieverModule(reactContext: ReactApplicationContext) :
           gain = ReplayGainParser(metadata[i]).gain
           if (gain != null) break
         }
-        
+
         if (gain != null) break
       }
 

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataRetrieverModule.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataRetrieverModule.kt
@@ -283,6 +283,8 @@ class MetadataRetrieverModule(reactContext: ReactApplicationContext) :
 
           if (isLyricsSync) break
         }
+
+        if (isLyricsSync) break
       }
 
       if (lyricsStr !== null) lyricsStr = lyricsStr.replace("\u0000", "")
@@ -313,6 +315,8 @@ class MetadataRetrieverModule(reactContext: ReactApplicationContext) :
           gain = ReplayGainParser(metadata[i]).gain
           if (gain != null) break
         }
+        
+        if (gain != null) break
       }
 
       promise.resolve(gain)

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataRetrieverModule.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/modules/MetadataRetrieverModule.kt
@@ -18,6 +18,7 @@ import com.cyanchill.missingcore.metadataretriever.models.ArtworkOptions
 import com.cyanchill.missingcore.metadataretriever.models.BridgeReturnables.*
 import com.cyanchill.missingcore.metadataretriever.utils.MapUtils
 import com.cyanchill.missingcore.metadataretriever.utils.Normalization
+import com.cyanchill.missingcore.metadataretriever.utils.ReplayGainParser
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
@@ -297,6 +298,34 @@ class MetadataRetrieverModule(reactContext: ReactApplicationContext) :
       }
     } catch (e: Exception) {
       promise.reject("ERR_LYRIC", e.message, e)
+    }
+  }
+
+  override fun getR128Gain(uri: String, promise: Promise) {
+    try {
+      val metadataList = getMetadataList(getFormatList(uri))
+      var gain: Float? = null
+
+      for (metadata in metadataList) {
+        val numEntries = metadata.length()
+        // Manually iterate over metadata entries to find a supported key.
+        for (i in 0 until numEntries) {
+          gain = ReplayGainParser(metadata[i]).gain
+          if (gain != null) break
+        }
+      }
+
+      promise.resolve(gain)
+    } catch (e: ExecutionException) {
+      val isWantedException =
+        e.message?.contains("androidx.media3.datasource.FileDataSource\$FileDataSourceException")
+          ?: false
+      when (isWantedException) {
+        true -> promise.reject("ENOENT", "ENOENT: No such file or directory (${uri})", e)
+        false -> promise.reject("ERR_REPLAY_GAIN", e.message, e)
+      }
+    } catch (e: Exception) {
+      promise.reject("ERR_REPLAY_GAIN", e.message, e)
     }
   }
 

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/utils/ReplayGainParser.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/utils/ReplayGainParser.kt
@@ -23,7 +23,9 @@ class ReplayGainParser(entry: Metadata.Entry) {
 
   private fun handleTextInformationFrame(frame: TextInformationFrame): Float? =
     when (frame.description?.uppercase()) {
-      in COMMON_REPLAY_GAIN_TAGS -> frame.values[0].parseReplayGainAdjustment()
+      "REPLAYGAIN_TRACK_GAIN" -> frame.values.firstOrNull()?.parseReplayGainAdjustment()
+      //? R128 gain needs to be divided by `256f`.
+      "R128_TRACK_GAIN" -> frame.values.firstOrNull()?.parseReplayGainAdjustment()?.div(256f)
       else -> null
     }
 
@@ -34,15 +36,13 @@ class ReplayGainParser(entry: Metadata.Entry) {
 
   private fun handleVorbisComment(comment: VorbisComment): Float? =
     when (comment.key.uppercase()) {
-      in COMMON_REPLAY_GAIN_TAGS -> comment.value.parseReplayGainAdjustment()
+      "REPLAYGAIN_TRACK_GAIN" -> comment.value.parseReplayGainAdjustment()
+      //? R128 gain needs to be divided by `256f`.
+      "R128_TRACK_GAIN" -> comment.value.parseReplayGainAdjustment()?.div(256f)
       else -> null
     }
 
   /** Some replay gain tags include "dB" in the string. */
   private fun String.parseReplayGainAdjustment() =
     replace(Regex("[^\\d.-]"), "").toFloatOrNull()
-
-  companion object {
-    private val COMMON_REPLAY_GAIN_TAGS = listOf("REPLAYGAIN_TRACK_GAIN", "R128_TRACK_GAIN")
-  }
 }

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/utils/ReplayGainParser.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/utils/ReplayGainParser.kt
@@ -1,0 +1,36 @@
+package com.cyanchill.missingcore.metadataretriever.utils
+
+import androidx.annotation.OptIn
+import androidx.media3.common.Metadata
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.extractor.metadata.id3.TextInformationFrame
+import androidx.media3.extractor.mp3.Mp3InfoReplayGain
+
+@OptIn(UnstableApi::class)
+class ReplayGainParser(entry: Metadata.Entry) {
+  var gain: Float? = null
+
+  init {
+    // Extract track gain based on the class.
+    gain = when (entry) {
+      is TextInformationFrame -> handleTextInformationFrame(entry)
+      is Mp3InfoReplayGain -> handleMp3InfoReplayGain(entry)
+      else -> null
+    }
+  }
+
+  private fun handleTextInformationFrame(frame: TextInformationFrame): Float? =
+    when (frame.description?.uppercase()) {
+      "REPLAYGAIN_TRACK_GAIN" -> frame.values[0].parseReplayGainAdjustment()
+      else -> null
+    }
+
+  /** For when we see `ReplayGain Xing/Info`. */
+  private fun handleMp3InfoReplayGain(frame: Mp3InfoReplayGain): Float? {
+    return frame.field1?.gain
+  }
+
+  /** Some replay gain tags include "dB" in the string. */
+  private fun String.parseReplayGainAdjustment() =
+    replace(Regex("[^\\d.-]"), "").toFloatOrNull()
+}

--- a/android/src/main/java/com/cyanchill/missingcore/metadataretriever/utils/ReplayGainParser.kt
+++ b/android/src/main/java/com/cyanchill/missingcore/metadataretriever/utils/ReplayGainParser.kt
@@ -4,6 +4,7 @@ import androidx.annotation.OptIn
 import androidx.media3.common.Metadata
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.extractor.metadata.id3.TextInformationFrame
+import androidx.media3.extractor.metadata.vorbis.VorbisComment
 import androidx.media3.extractor.mp3.Mp3InfoReplayGain
 
 @OptIn(UnstableApi::class)
@@ -15,13 +16,14 @@ class ReplayGainParser(entry: Metadata.Entry) {
     gain = when (entry) {
       is TextInformationFrame -> handleTextInformationFrame(entry)
       is Mp3InfoReplayGain -> handleMp3InfoReplayGain(entry)
+      is VorbisComment -> handleVorbisComment(entry)
       else -> null
     }
   }
 
   private fun handleTextInformationFrame(frame: TextInformationFrame): Float? =
     when (frame.description?.uppercase()) {
-      "REPLAYGAIN_TRACK_GAIN" -> frame.values[0].parseReplayGainAdjustment()
+      in COMMON_REPLAY_GAIN_TAGS -> frame.values[0].parseReplayGainAdjustment()
       else -> null
     }
 
@@ -30,7 +32,17 @@ class ReplayGainParser(entry: Metadata.Entry) {
     return frame.field1?.gain
   }
 
+  private fun handleVorbisComment(comment: VorbisComment): Float? =
+    when (comment.key.uppercase()) {
+      in COMMON_REPLAY_GAIN_TAGS -> comment.value.parseReplayGainAdjustment()
+      else -> null
+    }
+
   /** Some replay gain tags include "dB" in the string. */
   private fun String.parseReplayGainAdjustment() =
     replace(Regex("[^\\d.-]"), "").toFloatOrNull()
+
+  companion object {
+    private val COMMON_REPLAY_GAIN_TAGS = listOf("REPLAYGAIN_TRACK_GAIN", "R128_TRACK_GAIN")
+  }
 }

--- a/src/NativeMetadataRetriever.ts
+++ b/src/NativeMetadataRetriever.ts
@@ -62,6 +62,8 @@ export interface Spec extends TurboModule {
 
   getLyric(uri: string): Promise<string | null>;
 
+  getR128Gain(uri: string): Promise<number | null>;
+
   updateConfigs(options: ConfigOptions): Promise<void>;
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,13 @@ export async function getLyric(uri: string): Promise<string | null> {
 }
 //#endregion
 
+//#region Replay Gain
+/** Returns the replay gain for the track. */
+export async function getR128Gain(uri: string): Promise<number | null> {
+  return MetadataRetriever.getR128Gain(uri);
+}
+//#endregion
+
 //#region Configuration
 /** Update internal configuration options. */
 export async function updateConfigs(options: ConfigOptions): Promise<void> {


### PR DESCRIPTION
This PR introduces a new `getR128Gain` function that returns the track replay gain value in the embedded metadata. Currently, we support and verified:
- `REPLAYGAIN_TRACK_GAIN` in `TXXX` tag for ID3v2.
  - Represented by the `TextInformationFrame` class.
- `ReplayGain Xing/Info` tag for ID3v2.
  - Represented by the `Mp3InfoReplayGain` class.

> [!NOTE]
> We also support `R128_TRACK_GAIN` in `TXXX` tag, but have no files to verify.
>
> We also support both tags in `VorbisComment`, but have no files to verify.

Supposedly, the range of values returned should be within `± 20`.

### Examples of Replay Gain in Embedded Metadata

```
entries=[
  TIT2: description=null: values=[One Way],
  ReplayGain Xing/Info: peak=0.0, field 1=GainField{name=1, originator=3, gain=-8.6}, field 2=null
]

entries=[
  TXXX: description=REPLAYGAIN_ALGORITHM: values=[BS.1770],
  TXXX: description=comment: values=[:R128_TRACK_GAIN:],
  TXXX: description=REPLAYGAIN_TRACK_GAIN: values=[-1.63 dB],
  TXXX: description=REPLAYGAIN_TRACK_PEAK: values=[0.588893],
  TXXX: description=REPLAYGAIN_ALBUM_GAIN: values=[-1.63 dB],
  TXXX: description=REPLAYGAIN_ALBUM_PEAK: values=[0.588893],
  TXXX: description=REPLAYGAIN_REFERENCE_LOUDNESS: values=[-18.00 LUFS],
  TXXX: description=REPLAYGAIN_TRACK_RANGE: values=[1.07 dB],
  TXXX: description=REPLAYGAIN_ALBUM_RANGE: values=[1.07 dB]
]

entries=[
  TXXX: description=replaygain_reference_loudness: values=[89.0 dB],
  TXXX: description=replaygain_track_gain: values=[+0.655000 dB],
  TXXX: description=replaygain_track_peak: values=[0.443497],
  TXXX: description=replaygain_album_gain: values=[-0.040000 dB],
  TXXX: description=replaygain_album_peak: values=[0.449919],
  TXXX: description=MP3GAIN_MINMAX: values=[110,181],
  TXXX: description=MP3GAIN_ALBUM_MINMAX: values=[061,205],
  TXXX: description=MP3GAIN_UNDO: values=[+005,+005,N]
]
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public API to fetch R128 replay gain values from audio tracks.

* **Bug Fixes**
  * Improved lyric extraction to more safely handle text frames and stop earlier for synchronized lyrics.

* **Documentation**
  * Updated the API reference with the new replay-gain function and its signature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->